### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Get the status of google.com'
-        uses: im-open/url-status-check@v1.0.1
+        uses: im-open/url-status-check@v1.1.0
         with:
           url: 'https://www.google.com/'
           fail-on-bad-status: false

--- a/src/url-status-check.ps1
+++ b/src/url-status-check.ps1
@@ -10,8 +10,8 @@ try {
     Write-Output "Status Code: $($response.StatusCode)"
     Write-Output "Content: $($response.Content)"
 
-    echo "status_code=$($response.StatusCode)" >> $GITHUB_OUTPUT
-    echo "content=$($response.Content)" >> $GITHUB_OUTPUT
+    "status_code=$($response.StatusCode)" >> $env:GITHUB_OUTPUT
+    "content=$($response.Content)" >> $env:GITHUB_OUTPUT
 
     if ($errorOnBadStatus -and $response.StatusCode -ge 400) {
         throw "The status code $($response.StatusCode) indicates either a problem with the request or the application running at $url."

--- a/src/url-status-check.ps1
+++ b/src/url-status-check.ps1
@@ -10,8 +10,8 @@ try {
     Write-Output "Status Code: $($response.StatusCode)"
     Write-Output "Content: $($response.Content)"
 
-    echo "::set-output name=status_code::$($response.StatusCode)"
-    echo "::set-output name=content::$($response.Content)"
+    echo "status_code=$($response.StatusCode)" >> $GITHUB_OUTPUT
+    echo "content=$($response.Content)" >> $GITHUB_OUTPUT
 
     if ($errorOnBadStatus -and $response.StatusCode -ge 400) {
         throw "The status code $($response.StatusCode) indicates either a problem with the request or the application running at $url."


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.
- The output is set in powershell so the syntax is slightly different than the normal bash syntax.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
