### PR TITLE
ARCH-1805 - Update increment workflow to produce multiple tags

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -37,13 +37,22 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: false
 
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2
+        id: version
         with:
-          create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          default-release-type: major
+
+      - name: Create version tag, create or update major, and minor tags
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MINOR_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
+          git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f
+          git push origin ${{ steps.version.outputs.NEXT_MINOR_VERSION }} -f

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ A GitHub Action that will ping a url and output the status code and content from
   - [License](#license)
 
 ## Inputs
+
 | Parameter            | Is Required | Default | Description                                                                                                                                   |
 | -------------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`                | true        | N/A     | The url to ping.                                                                                                                              |
 | `fail-on-bad-status` | false       | true    | A flag that specifies whether or not to fail the action when a 400 or higher status code is returned. The expected values are true and false. |
 
 ## Outputs
+
 | Output        | Description                               |
 | ------------- | ----------------------------------------- |
 | `status_code` | The status code returned by the request.  |
@@ -34,7 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Get the status of google.com'
-        uses: im-open/url-status-check@v1.1.0
+        uses: im-open/url-status-check@v1.1.1
         with:
           url: 'https://www.google.com/'
           fail-on-bad-status: false


### PR DESCRIPTION
# Summary of PR changes

- Updating the increment workflow to be consistent with other builds.  Produce a tag for major, major.minor and major.minor.patch versions.


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
